### PR TITLE
Add support for other domains

### DIFF
--- a/getcourse-video-downloader.sh
+++ b/getcourse-video-downloader.sh
@@ -31,8 +31,7 @@ trap 'rm -fr "$tmpdir"' EXIT
 
 if [ -z "${1:-}" ] || \
    [ -z "${2:-}" ] || \
-   [ -n "${3:-}" ] || \
-   ! [[ "$1" =~ ^http(s|)://.*getcourse.ru/.* ]]
+   [ -n "${3:-}" ]
 then
 	_echo_help
 	exit 1
@@ -51,7 +50,7 @@ curl -L --output "$second_playlist" "$(tail -n1 "$main_playlist")"
 c=0
 while read -r line
 do
-	if ! [[ "$line" =~ ^http(s|):// ]]; then continue; fi
+	if ! [[ "$line" =~ ^http ]]; then continue; fi
 	curl -L --output "${tmpdir}/$(printf '%05d' "$c").ts" "$line"
 	c=$((++c))
 done < "$second_playlist"


### PR DESCRIPTION
Первое — спасибо за скрипт, это гениально и оно реально работает.

Второе — пришлось убрать проверку домена getcourse, потому что, например, в моем случае домен с плейлистом: `https://playlist.kinescopecdn.net`
Третье — так же на 54-ей строке убрал `(s|)`. С ним не хотел скачивать файлы.

При таком скрипте все отлично отрабатывает.

p.s. наверное, лучше поправить, чтобы было по-красоте.