### PR TITLE
Fix regexp for detecting .ts urls

### DIFF
--- a/getcourse-video-downloader.sh
+++ b/getcourse-video-downloader.sh
@@ -47,7 +47,7 @@ curl -L --output "$main_playlist" "$URL"
 second_playlist="$(mktemp)"
 # Бывает (я встречал) 2 варианта видео
 # Может быть, можно проверять [[ "$URL" =~ .*".m3u8".* ]]
-if grep -qE '^http(s|)://.*\.ts' "$main_playlist"
+if grep -qE '^https?:\/\/.*\.ts' "$main_playlist"
 then
 	# В плей-листе перечислены напрямую ссылки на фрагменты видео
 	# (если запустили проигрывание, зашли в инструменты разработчика Chromium -> Network,


### PR DESCRIPTION
У меня регулярка из вашего скрипта не работала. Мб дело в разной обработке регэксов на разых системах или версиях баша (у меня MacOS).
Отладчик показал, что слэши должны экранироваться. Поменял на такой вариант https://regex101.com/r/t5dv6C/1 - заработало.
Ну и определение наличия https сделал полаконичней)

Спасибо за скрипт!