### PR TITLE
Add retry parameter

### DIFF
--- a/getcourse-video-downloader.sh
+++ b/getcourse-video-downloader.sh
@@ -73,7 +73,7 @@ c=0
 while read -r line
 do
 	if ! [[ "$line" =~ ^http ]]; then continue; fi
-	curl -L --output "${tmpdir}/$(printf '%05d' "$c").ts" "$line"
+	curl --retry 999 -L --output "${tmpdir}/$(printf '%05d' "$c").ts" "$line"
 	c=$((++c))
 done < "$second_playlist"
 


### PR DESCRIPTION
Hi! Thank you for such useful script!
Sometimes curl may fail due to network problems, so the whole downloading is interrupted. Curl may retry each request. Let's add It.